### PR TITLE
url 주소를 kyuwon53에서 Kyuwon53으로 수정하라

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ description: > # this means to ignore newlines until "show_exerpts:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 show_excerpts: true # set to true to show excerpts on the homepage
-url: https://kyuwon53.github.io/
+url: https://Kyuwon53.github.io/
 baseurl: ""
 
 # Minima date format


### PR DESCRIPTION
깃허브 블로그는 유저아이디.github.io로 설정이되는데 
유저아이디가 Kyuwon53 인데 kyuwon53으로 설정되어 변경
페이지가 반영이 안되서 url 주소 변경